### PR TITLE
Chang API URL definition to use config.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,9 @@ First time
 use `APC(u)` and `Synchronous`.
 7. Connect to Cachet and create components and metrics used by the monitor
 8. Get the token of the user (in 172.0.3.2:8000/dashboard/user)
-9. Modify the token on the monitor configuration file: [config.yml](cachet-url-monitor-conf/config.yml)
-10. Start the monitor:
+9. Modify the API URL on the monitor configuration file: [config.yml](cachet-url-monitor-conf/config.yml)
+10. Modify the token on the monitor configuration file: [config.yml](cachet-url-monitor-conf/config.yml)
+11. Start the monitor:
 
         docker-compose up -d monitor
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
       context: ./cachet-url-monitor
     image: cachet-url-monitor
     environment:
-      - CACHET_API=172.0.3.2:8000/api/v1
       - CACHET_DEV=false
     volumes:
       - .monitor-config.yml:/usr/src/app/config/config.yml

--- a/monitor-config.yml
+++ b/monitor-config.yml
@@ -20,9 +20,7 @@ endpoints:
     latency_unit: ms
     frequency: 60 # in seconds
 cachet:
-  api_url:
-    - type: ENVIRONMENT_VARIABLE
-      value: CACHET_API
+  api_url: http://172.0.3.2:8000/api/v1
   token:
     - type: TOKEN
       value: my_token


### PR DESCRIPTION
The provided `config.yml` file does not work as the `api_url` needs to be hardcoded in it, as opposed to attempting to use the `ENVIRONMENT_VARIABLE` flag. This PR updates the `config.yml` to have that change, the `docker-compose.yml` to remove the provided environment variable, and the `README.md` to provide the new instructions.